### PR TITLE
Biz data deploy

### DIFF
--- a/index-entitydb.ts
+++ b/index-entitydb.ts
@@ -863,13 +863,19 @@ class CustomEmbed extends LibraryBase {
                             approvers: this.dataSet.Approvers,
                         };
 
-                        await window.loomeApi.runApiRequest(API_SUBMIT_DATASET_REQUEST, {
+                        const response = await window.loomeApi.runApiRequest(API_SUBMIT_DATASET_REQUEST, {
                             DataSetID: formData.datasetId,
                             approvers: formData.approvers,
                             assistProjectID: parseInt(formData.projectId),
                             purpose: formData.purpose,
                             requestName: formData.requestName,
                         });
+
+                        if (response && response.status_code && response.status_code >= 400) {
+                            console.error(`Error ${response.status_code}: ${response.detail}`);
+                            alert(`Error ${response.status_code}: ${response.detail}`);
+                            return;
+                        }
                         
                         alert('Request submitted successfully!');
                         

--- a/index-entitydb.ts
+++ b/index-entitydb.ts
@@ -26,7 +26,7 @@ interface DataSetColumn {
     LogicalColumnName: string;
     BusinessDescription: string;
     ExampleValue: string;
-    Tokenise: boolean;
+    Deidentify: boolean;
     TokenIdentifierType: number;
     Redact: boolean;
     DisplayOrder: number;
@@ -273,7 +273,7 @@ class CustomEmbed extends LibraryBase {
                                             </div>
                                         </div>
                                     </th>
-                                    <th data-sort="Tokenise" class="header-filter-cell">
+                                    <th data-sort="Deidentify" class="header-filter-cell">
                                         <div class="header-filter">
                                             <span class="header-text">Deidentified</span>
                                             <button type="button" id="deidentifiedToggle" class="filter-icon" aria-haspopup="true" aria-expanded="false" title="Filter Deidentified">
@@ -1082,7 +1082,7 @@ class CustomEmbed extends LibraryBase {
                     <td>${column.BusinessDescription || 'N/A'}</td>
                     <td><span class="code-cell">${column.ExampleValue || 'N/A'}</span></td>
                     <td>${column.Redact ? '<span class="mui-chip success">Yes</span>' : '<span class="mui-chip">No</span>'}</td>
-                    <td>${column.Tokenise ? '<span class="mui-chip success">Yes</span>' : '<span class="mui-chip">No</span>'}</td>
+                    <td>${column.Deidentify ? '<span class="mui-chip success">Yes</span>' : '<span class="mui-chip">No</span>'}</td>
                 </tr>
             `;
         });
@@ -1241,8 +1241,8 @@ class CustomEmbed extends LibraryBase {
         if (this.redactedFilter === 'yes') filtered = filtered.filter(c => Boolean(c.Redact));
         else if (this.redactedFilter === 'no') filtered = filtered.filter(c => !Boolean(c.Redact));
 
-        if (this.deidentifiedFilter === 'yes') filtered = filtered.filter(c => Boolean(c.Tokenise));
-        else if (this.deidentifiedFilter === 'no') filtered = filtered.filter(c => !Boolean(c.Tokenise));
+        if (this.deidentifiedFilter === 'yes') filtered = filtered.filter(c => Boolean(c.Deidentify));
+        else if (this.deidentifiedFilter === 'no') filtered = filtered.filter(c => !Boolean(c.Deidentify));
 
         // Apply sorting
         if (this.currentSortColumn) {

--- a/index-entityfolder.ts
+++ b/index-entityfolder.ts
@@ -863,14 +863,20 @@ class CustomEmbed extends LibraryBase {
                         };
 
 
-                        await window.loomeApi.runApiRequest(API_REQUEST_DATASET, {
+                        const response = await window.loomeApi.runApiRequest(API_REQUEST_DATASET, {
                             DataSetID: formData.datasetId,
                             approvers: formData.approvers,
                             assistProjectID: parseInt(formData.projectId),
                             purpose: formData.purpose,
                             requestName: formData.requestName,
                         });
-                        
+
+                        if (response && response.status_code && response.status_code >= 400) {
+                            console.error(`Error ${response.status_code}: ${response.detail}`);
+                            alert(`Error ${response.status_code}: ${response.detail}`);
+                            return;
+                        }
+                         
                         alert('Request submitted successfully!');
                         
                         // Close the modal on success

--- a/index-entityfolder.ts
+++ b/index-entityfolder.ts
@@ -15,7 +15,7 @@ interface DataSetColumn {
     LogicalColumnName: string;
     BusinessDescription: string;
     ExampleValue: string;
-    Tokenise: boolean;
+    Deidentify: boolean;
     TokenIdentifierType: number;
     Redact: boolean;
     DisplayOrder: number;
@@ -70,7 +70,7 @@ interface DataSetFolderFile {
     FileType: string;
     FileDescription: string;
     Redact: boolean;
-    Tokenise: boolean;
+    Deidentify: boolean;
     DataSetFolderFileID: number;
     DataSetFolderID: number;
     FolderName: string;
@@ -275,7 +275,7 @@ class CustomEmbed extends LibraryBase {
                                             </div>
                                         </div>
                                     </th>
-                                    <th data-sort="Tokenise" class="header-filter-cell">
+                                    <th data-sort="Deidentify" class="header-filter-cell">
                                         <div class="header-filter">
                                             <span class="header-text">Deidentified</span>
                                             <button type="button" id="deidentifiedToggle" class="filter-icon" aria-haspopup="true" aria-expanded="false" title="Filter Deidentified">
@@ -1070,7 +1070,7 @@ class CustomEmbed extends LibraryBase {
                         <td><span class="mui-chip">${fileType}</span></td>
                         <td>${description}</td>
                         <td>${file.Redact ? '<span class="mui-chip success">Yes</span>' : '<span class="mui-chip">No</span>'}</td>
-                        <td>${file.Tokenise ? '<span class="mui-chip success">Yes</span>' : '<span class="mui-chip">No</span>'}</td>
+                        <td>${file.Deidentify ? '<span class="mui-chip success">Yes</span>' : '<span class="mui-chip">No</span>'}</td>
                     </tr>
                 `;
             });
@@ -1266,9 +1266,9 @@ class CustomEmbed extends LibraryBase {
         }
 
         if (this.deidentifiedFilter === 'yes') {
-            results = results.filter(c => Boolean(c.Tokenise));
+            results = results.filter(c => Boolean(c.Deidentify));
         } else if (this.deidentifiedFilter === 'no') {
-            results = results.filter(c => !Boolean(c.Tokenise));
+            results = results.filter(c => !Boolean(c.Deidentify));
         }
 
         if (this.currentSortColumn) {

--- a/index-entityredcap.ts
+++ b/index-entityredcap.ts
@@ -8,7 +8,7 @@ interface DataSetColumn {
     LogicalColumnName: string;
     BusinessDescription: string;
     ExampleValue: string;
-    Tokenise: boolean;
+    Deidentify: boolean;
     TokenIdentifierType: number;
     Redact: boolean;
     DisplayOrder: number;
@@ -242,7 +242,7 @@ class CustomEmbed extends LibraryBase {
                                             </div>
                                         </div>
                                     </th>
-                                    <th data-sort="Tokenise" class="header-filter-cell">
+                                    <th data-sort="Deidentify" class="header-filter-cell">
                                         <div class="header-filter">
                                             <span class="header-text">Deidentified</span>
                                             <button type="button" id="deidentifiedToggle" class="filter-icon" aria-haspopup="true" aria-expanded="false" title="Filter Deidentified">
@@ -1047,7 +1047,7 @@ class CustomEmbed extends LibraryBase {
                         <td>${businessDescription}</td>
                         <td><span class="code-cell">${exampleValue}</span></td>
                         <td>${column.Redact ? '<span class="mui-chip success">Yes</span>' : '<span class="mui-chip">No</span>'}</td>
-                        <td>${column.Tokenise ? '<span class="mui-chip success">Yes</span>' : '<span class="mui-chip">No</span>'}</td>
+                        <td>${column.Deidentify ? '<span class="mui-chip success">Yes</span>' : '<span class="mui-chip">No</span>'}</td>
                     </tr>
                 `;
             });
@@ -1252,11 +1252,11 @@ class CustomEmbed extends LibraryBase {
             results = results.filter(c => !Boolean(c.Redact));
         }
 
-        // Apply deidentified (Tokenise) filter
+        // Apply deidentified (Deidentify) filter
         if (this.deidentifiedFilter === 'yes') {
-            results = results.filter(c => Boolean(c.Tokenise));
+            results = results.filter(c => Boolean(c.Deidentify));
         } else if (this.deidentifiedFilter === 'no') {
-            results = results.filter(c => !Boolean(c.Tokenise));
+            results = results.filter(c => !Boolean(c.Deidentify));
         }
 
         // Apply sorting

--- a/index-entityredcap.ts
+++ b/index-entityredcap.ts
@@ -155,8 +155,8 @@ class CustomEmbed extends LibraryBase {
                                     <input id="RequestName" class="form-input" placeholder="Name for this request" required>
                                 </div>
                                 <div class="form-group">
-                                    <label for="RequestDescription">Description</label>
-                                    <input id="RequestDescription" class="form-input" placeholder="Description for this request" required>
+                                    <label for="RequestPurpose">Purpose</label>
+                                    <input id="RequestPurpose" class="form-input" placeholder="Purpose for this request" required maxlength="255">
                                 </div>
                                 <div class="form-group">
                                     <label for="ProjectID">Assist Project</label>
@@ -225,6 +225,7 @@ class CustomEmbed extends LibraryBase {
                                             </div>
                                         </div>
                                     </th>
+                                    <th data-sort="ColumnType">Column Type</th>
                                     <th data-sort="LogicalColumnName">Logical Name</th>
                                     <th data-sort="BusinessDescription">Description</th>
                                     <th data-sort="ExampleValue">Example</th>
@@ -237,7 +238,7 @@ class CustomEmbed extends LibraryBase {
                                             <div class="popover" id="redactedPopover">
                                                 <div class="popover-option" data-value="yes">Yes</div>
                                                 <div class="popover-option" data-value="no">No</div>
-                                                <div class="popover-option" data-value="all">Show All</div>
+                                                <div class="popover-option" data-value="all">All Data</div>
                                             </div>
                                         </div>
                                     </th>
@@ -250,7 +251,7 @@ class CustomEmbed extends LibraryBase {
                                             <div class="popover" id="deidentifiedPopover">
                                                 <div class="popover-option" data-value="yes">Yes</div>
                                                 <div class="popover-option" data-value="no">No</div>
-                                                <div class="popover-option" data-value="all">Show All</div>
+                                                <div class="popover-option" data-value="all">All Data</div>
                                             </div>
                                         </div>
                                     </th>
@@ -823,7 +824,7 @@ class CustomEmbed extends LibraryBase {
                         const formData = {
                             requestName: (document.getElementById('RequestName') as HTMLInputElement)?.value,
                             projectId: (document.getElementById('ProjectID') as HTMLSelectElement)?.value,
-                            description: (document.getElementById('RequestDescription') as HTMLInputElement)?.value,
+                            purpose: (document.getElementById('RequestPurpose') as HTMLInputElement)?.value,
                             datasetId: this.dataSet.DataSetID,
                             approvers: this.dataSet.Approvers,
                         };
@@ -832,7 +833,7 @@ class CustomEmbed extends LibraryBase {
                             DataSetID: formData.datasetId,
                             approvers: formData.approvers,
                             assistProjectID: parseInt(formData.projectId),
-                            description: formData.description,
+                            purpose: formData.purpose,
                             requestName: formData.requestName,
                         });
                         
@@ -1034,12 +1035,14 @@ class CustomEmbed extends LibraryBase {
         } else {
             paginatedColumns.forEach((column: DataSetColumn) => {
                 const columnName = this.escapeHtml(column.ColumnName);
+                const columnType = this.escapeHtml(column.ColumnType);                
                 const logicalColumnName = this.escapeHtml(column.LogicalColumnName);
                 const businessDescription = column.BusinessDescription ? this.escapeHtml(column.BusinessDescription) : 'N/A';
                 const exampleValue = column.ExampleValue ? this.escapeHtml(column.ExampleValue) : 'N/A';
                 columnsHtml += `
                     <tr>
                         <td>${columnName}</td>
+                        <td><span class="mui-chip">${columnType || ''}</span></td>
                         <td>${logicalColumnName}</td>
                         <td>${businessDescription}</td>
                         <td><span class="code-cell">${exampleValue}</span></td>

--- a/index-entityredcap.ts
+++ b/index-entityredcap.ts
@@ -829,14 +829,20 @@ class CustomEmbed extends LibraryBase {
                             approvers: this.dataSet.Approvers,
                         };
 
-                        await window.loomeApi.runApiRequest(API_SUBMIT_DATASET_REQUEST, {
+                        const response = await window.loomeApi.runApiRequest(API_SUBMIT_DATASET_REQUEST, {
                             DataSetID: formData.datasetId,
                             approvers: formData.approvers,
                             assistProjectID: parseInt(formData.projectId),
                             purpose: formData.purpose,
                             requestName: formData.requestName,
                         });
-                        
+
+                        if (response && response.status_code && response.status_code >= 400) {
+                            console.error(`Error ${response.status_code}: ${response.detail}`);
+                            alert(`Error ${response.status_code}: ${response.detail}`);
+                            return;
+                        }
+                         
                         alert('Request submitted successfully!');
                         
                         // Close the modal on success


### PR DESCRIPTION
This pull request standardizes the terminology across the codebase by renaming the `Tokenise` property to `Deidentify` in all relevant interfaces, UI elements, and filtering logic. This change affects the display, sorting, and filtering of data columns and files in the `index-entitydb.ts`, `index-entityfolder.ts`, and `index-entityredcap.ts` files to ensure consistent and clear language for de-identification functionality.

**Property and Interface Updates:**

* Renamed the `Tokenise` property to `Deidentify` in all `DataSetColumn` and `DataSetFolderFile` interfaces to reflect the updated terminology. [[1]](diffhunk://#diff-4a6aa6103f090337c225b8ed6dd790c290a31dda3883d6ef29f314f5d4403ba2L29-R29) [[2]](diffhunk://#diff-e8a2fb1e978c190a98ea96363376180ad330ff9c959a108c0c4f5b41b3c72e4dL18-R18) [[3]](diffhunk://#diff-e8a2fb1e978c190a98ea96363376180ad330ff9c959a108c0c4f5b41b3c72e4dL73-R73) [[4]](diffhunk://#diff-a73d7dbd7bf53c4f2f2d2469bfa01ff1df9975b2639d8e1a080f56af50e74efcL11-R11)

**UI and Display Changes:**

* Updated all table headers, filter buttons, and displayed labels from "Tokenise" to "Deidentified" for clarity and consistency in the user interface. [[1]](diffhunk://#diff-4a6aa6103f090337c225b8ed6dd790c290a31dda3883d6ef29f314f5d4403ba2L276-R276) [[2]](diffhunk://#diff-e8a2fb1e978c190a98ea96363376180ad330ff9c959a108c0c4f5b41b3c72e4dL278-R278) [[3]](diffhunk://#diff-a73d7dbd7bf53c4f2f2d2469bfa01ff1df9975b2639d8e1a080f56af50e74efcL245-R245)
* Changed all table cell displays to use the `Deidentify` property instead of `Tokenise` when showing whether a column or file is de-identified. [[1]](diffhunk://#diff-4a6aa6103f090337c225b8ed6dd790c290a31dda3883d6ef29f314f5d4403ba2L1085-R1085) [[2]](diffhunk://#diff-e8a2fb1e978c190a98ea96363376180ad330ff9c959a108c0c4f5b41b3c72e4dL1073-R1073) [[3]](diffhunk://#diff-a73d7dbd7bf53c4f2f2d2469bfa01ff1df9975b2639d8e1a080f56af50e74efcL1050-R1050)

**Filtering Logic Updates:**

* Updated all filter logic to use the `Deidentify` property instead of `Tokenise` when filtering for de-identified columns or files. [[1]](diffhunk://#diff-4a6aa6103f090337c225b8ed6dd790c290a31dda3883d6ef29f314f5d4403ba2L1244-R1245) [[2]](diffhunk://#diff-e8a2fb1e978c190a98ea96363376180ad330ff9c959a108c0c4f5b41b3c72e4dL1269-R1271) [[3]](diffhunk://#diff-a73d7dbd7bf53c4f2f2d2469bfa01ff1df9975b2639d8e1a080f56af50e74efcL1255-R1259)